### PR TITLE
Fix: Increase memory size of pod

### DIFF
--- a/external-app-example/deploy/edge_example.tf
+++ b/external-app-example/deploy/edge_example.tf
@@ -86,11 +86,11 @@ resource "kubernetes_deployment_v1" "edge-example-app" {
           resources {
             requests = {
               cpu = "100m"
-              memory = "128Mi"
+              memory = "256Mi"
             }
             limits = {
               cpu = "100m"
-              memory = "128Mi"
+              memory = "256Mi"
             }
           }
           port {


### PR DESCRIPTION
Memory usage for the pod was at 80% when the spec was 128 megabytes. It has been increased to 256.