### PR TITLE
Fix broken dashboard example

### DIFF
--- a/dashboard-app-example/Dockerfile
+++ b/dashboard-app-example/Dockerfile
@@ -11,7 +11,7 @@ USER app_admin
 
 RUN edm install --version 3.8 click "flask>2" gunicorn requests -y
 
-RUN edm run -- python -m pip install "jupyterhub==2.2.2" dockerspawner "configurable-http-proxy" Flask-Session
+RUN edm run -- python -m pip install "jupyterhub==2.2.2" "sqlalchemy<2" dockerspawner "configurable-http-proxy" Flask-Session
 
 WORKDIR /home/app_admin
 COPY --chown=app_admin ./src dashboard-app-example/

--- a/dashboard-app-example/README.md
+++ b/dashboard-app-example/README.md
@@ -13,20 +13,17 @@ To build and run the example application you will need:
 
 ## Set up the development environment
 
-First, you will need to create an EDM environment named `dev_env` and install some dependencies.
+First, you will need to create an EDM environment and install some dependencies.
+To do this, use the "bootstrap.py" script:
 
 ```commandline
-edm install -e dev_env --version 3.8 -y click requests "flask>2" && \
-edm run -e dev_env -- python -m pip install "jupyterhub==2.2.2" \
-    dockerspawner \
-    "configurable-http-proxy" \
-    Flask-Session
-```   
+python bootstrap.py
+```
 
-Once you have created the `dev_env` environment, you may activate it with:
+This will create the `edge-dash-dev` EDM environment.  You may activate it with:
 
 ```commandline
-edm shell -e dev_env
+edm shell -e edge-dash-dev
 ```   
 
 ## Running the Application

--- a/dashboard-app-example/bootstrap.py
+++ b/dashboard-app-example/bootstrap.py
@@ -1,0 +1,52 @@
+# Enthought product code
+#
+# (C) Copyright 2010-2022 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This file and its contents are confidential information and NOT open source.
+# Distribution is prohibited.
+
+"""
+    Bootstrap file for the dashboard example.
+"""
+
+import subprocess
+
+ENV_NAME = "edge-dash-dev"
+
+EDM_DEPS = [
+    "click",
+    "requests",
+    "flask>2",
+]
+
+PIP_DEPS = [
+    "jupyterhub==2.2.2",
+    "sqlalchemy<2",
+    "configurable-http-proxy",
+    "dockerspawner",
+    "Flask-Session",
+]
+
+
+def bootstrap():
+    """Create and populate dev env"""
+
+    print("Creating EDM Python environment...")
+    cmd = ["edm", "envs", "create", ENV_NAME, "--version", "3.8", "--force"]
+    subprocess.run(cmd, check=True)
+
+    print("Installing EDM dependencies...")
+    cmd = ["edm", "install", "-e", ENV_NAME, "-y"] + EDM_DEPS
+    subprocess.run(cmd, check=True)
+
+    print("Installing pip dependencies...")
+    cmd = ["edm", "run", "-e", ENV_NAME, "--", "pip", "install"] + PIP_DEPS
+    subprocess.run(cmd, check=True)
+
+    print("Bootstrap complete.")
+    print(f'To use your new dev environment, run "edm shell -e {ENV_NAME}"')
+
+
+if __name__ == "__main__":
+    bootstrap()


### PR DESCRIPTION
Address https://github.com/enthought/edge-support/issues/3.

This particular problem seems to be caused by an incompatibility between our older JupyterHub version and newer version of SQLAlchemy (version 2+).  I also found the bootstrap instructions confusing so I put them in a script.