### PR TITLE
Update external example README/comments

### DIFF
--- a/Externally-Hosted/README.md
+++ b/Externally-Hosted/README.md
@@ -8,9 +8,9 @@ Edge.
 
 Edge provides two important mechanisms for integrating with externally-hosted
 apps.  First, you can register such an app on the Workbench, so that users
-can go straight to it after logging in.  Second, you can configure the
-externally-hosted app to use Edge as an _authentication provider_, using the
-industry-standard OAuth2 protocol.
+can go straight to it after logging in.  Second, you can set up the
+externally-hosted app's login flow to use Edge as a source of information on
+the user, via the industry-standard OAuth2 protocol.
 
 
 ## Overview
@@ -57,7 +57,7 @@ To build the application, use:
 python -m ci build
 ```
 
-You can run this application in debug mode without Edge authentication integration using:
+You can run this application in debug mode without Edge login integration using:
 
 ```commandline
 python -m ci watch
@@ -71,22 +71,22 @@ we will provide `client_id`, `client_secret` and `redirect_uri` to the
 [`authlib`](./src/app.py#L31) library.  These three pieces of information will
 come from the Edge registration process in step 3.
 
-The requirements for authentication in this example Flask application are handled
+The requirements for login in this example Flask application are handled
 in [`api/auth.py`](./api/auth.py). These include:
 - An [`authenticated` decorator](./src/api/auth.py#L25)
 - A [`/login` endpoint with OAuth redirect to Edge](./src/api/auth.py#L41)
-- A [`/authorize` endpoint](./src/api/auth.#L57) which will be the `redirect_uri` for handling Edge OAuth
+- A [`/authorize` endpoint](./src/api/auth.#L57) which will be the 
+`redirect_uri` for handling Edge OAuth
 
-Finally, keep in mind the Edge provides your application with the identity of
-the Edge user requesting access to your app, in the form of a user ID,
-typically an email address.  Edge guarantees that the user ID is genuine; in
-other words, the user is who they say they are.  This is _authentication_.
+Finally, keep in mind the Edge login flow grants your application basic
+identity information regarding a user, for example a user ID, typically an
+email address.
 
-Depending on your app's security model, you would likely also need to handle
-_authorization_.  Most apps won't want to simply allow any authenticated user to
-access information, because not every authenticated user may belong to the
+Depending on your app's security model, you would likely also need to provide
+a more detailed authorization process. Most apps won't want to simply allow any 
+user to access information, because not every Edge user may belong to the
 business unit or team working with the app.  Typically you will perform
-additional _authorization_ checks before allowing an authenticated user access.  
+additional checks before allowing an authenticated user access.  
 
 As an example, you might have a list of authorized user IDs in a database, or
 even in a config file that the app can load on startup. There is a

--- a/Externally-Hosted/src/api/auth.py
+++ b/Externally-Hosted/src/api/auth.py
@@ -23,7 +23,7 @@ auth = Blueprint("auth", __name__)
 
 
 def authenticated(f):
-    """Verify we have information o the user's ID"""
+    """Verify we have information on the user's ID"""
 
     @wraps(f)
     def decorated(*args, **kwargs):

--- a/Externally-Hosted/src/api/auth.py
+++ b/Externally-Hosted/src/api/auth.py
@@ -23,7 +23,7 @@ auth = Blueprint("auth", __name__)
 
 
 def authenticated(f):
-    """Verify if the user is authenticated"""
+    """Verify we have information o the user's ID"""
 
     @wraps(f)
     def decorated(*args, **kwargs):
@@ -49,7 +49,7 @@ def login():
             return redirect("/")
 
     redirect_uri = url_for("auth.authorize", _external=True)
-    # Redirect to OAuth provider (Edge) for authentication, then back
+    # Redirect to OAuth provider (Edge), then back
     # to our 'redirect_uri' callback to handle the response
     return app.OAUTH.authorize_redirect(redirect_uri)
 
@@ -63,7 +63,7 @@ def authorize():
 
     With the access token in hand, we query the provider for the user
     information and save the user ID in our session. This user ID will be used
-    throught the application to verify the identity of the signed-in user.
+    throught the application to identify the signed-in user.
     """
     try:
         app.OAUTH.authorize_access_token()
@@ -97,7 +97,7 @@ def logout():
 
 
 def user_is_authorized(user_id):
-    """ Stub function for checking if a particular user ID is allowed access.
+    """Stub function for checking if a particular user ID is allowed access.
 
     You can trust that the user_id is genuine; Edge guarantees this as part
     of the login process.  As the app developer, you're responsible for also


### PR DESCRIPTION
Towards #46.  Make the discussion in the Externally-Hosted example less confused regarding OAuth2, keeping in mind that we are limited at the moment to what JupyterHub provides in our pinned version.