### PR TITLE
57 Update Externally Hosted README

### DIFF
--- a/Externally-Hosted/README.md
+++ b/Externally-Hosted/README.md
@@ -43,7 +43,7 @@ Before starting, ensure you have the following installed:
 Collect the following information:
 
 * The hostname under which your app will be deployed.  For this example, we will
-  use "https://edge-external-app-demo.platform-devops.enthought.com".
+  use "https://edge-external-app-demo.edge-dev.enthought.com".
 * A Docker repository and related username/password.  For this example, we will
   use "quay.io/enthought/edge-external-app-demo".
 
@@ -111,7 +111,7 @@ dashboard, but gives developers freedom to publish new versions by themselves.
 Once your administrator has created the _app_, you can make a new _app version_
 by logging into Edge, going to the "gear" icon, and navigating to it.
 Click "Create Version" and fill out the form, being sure to set "Kind" to
-"Externally-Hosted App".  For the "Link", you should provide the hostname
+"Externally Hosted App".  For the "Link", you should provide the hostname
 from step (1).
 
 Once your app version is created, you will need to create the OAuth2
@@ -133,7 +133,7 @@ deploy the app.  It looks something like this:
 ```python
 {'client_id': 'service-edge-app-default-edge-external-app-demo',
  'client_secret': 'RANDOM_CLIENT_SECRET',
- 'redirect_uri': 'https://edge-external-app-demo.platform-devops.enthought.com/authorize'}
+ 'redirect_uri': 'https://edge-external-app-demo.edge-dev.enthought.com/authorize'}
  ```
 
 ## 4. Deploying the app

--- a/Externally-Hosted/deploy/README.md
+++ b/Externally-Hosted/deploy/README.md
@@ -3,7 +3,7 @@
 
 There are many ways to deploy a web application, such as Ansible or Helm.
 In this example, we are using Terraform to deploy the example application
-to Kubernetes, in a namespace called `edge-dev`.
+to Kubernetes, in a namespace called `external-app`.
 
 ## Requirements
 
@@ -14,7 +14,7 @@ The requirements are:
 - [`kubelogin`](https://github.com/int128/kubelogin)
 - [`terraform`](https://learn.hashicorp.com/tutorials/terraform/install-cli)
 - An Outh Client ID from Edge (see [`README.MD`](../README.md))
-- A `quay.io` username and password with access to the `quay.io/enthough/edge-external-app-demo` repo
+- A `quay.io` username and password with access to the `quay.io/enthought/edge-external-app-demo` repo
 
 ## Deploying Using Terraform
 
@@ -44,7 +44,7 @@ To check that your deployment succeded you can run `kubectl describe pod` or
 `kubectl describe deploy`.
 
 You can open the demo app in your browser by going to
-[`https://edge-external-app-demo.platform-devops.enthought.com`](https://edge-external-app-demo.platform-devops.enthought.com)
+[`https://edge-external-app-demo.edge-dev.enthought.com`](https://edge-external-app-demo.edge-dev.enthought.com)
 
 ## Deployment Configuration
 

--- a/Externally-Hosted/deploy/edge_example.tf
+++ b/Externally-Hosted/deploy/edge_example.tf
@@ -70,7 +70,7 @@ resource "kubernetes_deployment_v1" "edge-example-app-dev" {
           }
           env {
             name  = "OAUTH_REDIRECT_URI"
-            value = "http://edge-external-app-dev.edge-dev.enthought.com/authorize"
+            value = "https://edge-external-app-dev.edge-dev.enthought.com/authorize"
           }
           env {
             name  = "EDGE_BASE_URL"


### PR DESCRIPTION
(Closes #57 )

Successfully deployed the Externally-Hosted App example on edge-dev-main.enthought.com

## Updates

- Merged `main` into `edge-external-app-dev` branch
- Deployment process validated that it can be _deployed_ on `edge-dev-main` and _hosted_ at [edge-external-app-dev.edge-dev.enthought.com](https://edge-external-app-dev.edge-dev.enthought.com)
- Terraform deployment files are valid