### PR TITLE
Use proxy variables

### DIFF
--- a/Core/Plotly Dash/ci/__main__.py
+++ b/Core/Plotly Dash/ci/__main__.py
@@ -21,7 +21,7 @@ SRC_ROOT = op.abspath(op.join(op.dirname(__file__), ".."))
 
 # Docker image will be tagged "IMAGE:VERSION"
 IMAGE = "quay.io/enthought/edge-plotly-dash-core"
-VERSION = "1.1.0"
+VERSION = "1.2.0"
 
 # These will go into the built Docker image.  You may wish to modify this
 # minimal example to pin the dependencies, or use a bundle file to define them.

--- a/Core/Plotly Dash/src/app.py
+++ b/Core/Plotly Dash/src/app.py
@@ -23,10 +23,6 @@ from dash.dependencies import Input, Output
 from edge.api import EdgeSession
 from flask import Flask
 
-# Your app will be served by Edge under this URL prefix.
-# Please note the value will contain a trailing "/" character.
-PREFIX = os.environ.get("JUPYTERHUB_SERVICE_PREFIX", "/")
-
 
 def get_edge_session():
     """Helper function to get an EdgeSession object.
@@ -59,7 +55,7 @@ def get_edge_session():
 # "flask_app" instead.
 flask_app = Flask(__name__)
 
-dash_app = Dash(server=flask_app, url_base_pathname=PREFIX)
+dash_app = Dash(server=flask_app)
 
 
 df = pd.read_csv(


### PR DESCRIPTION
Publish a version 1.2.0 of edge-plotly-dash-core that defaults to using URL_BASE_PATHNAME variable, for compatibility with https://github.com/enthought/edge-product/pull/2310