### PR TITLE
80 - Switch to Rockylinux-8 and update versions

### DIFF
--- a/.github/workflows/test-examples.yaml
+++ b/.github/workflows/test-examples.yaml
@@ -20,27 +20,27 @@ jobs:
           {
             directory: "Minimal",
             environment: "edge-minimal-example",
-            image: "quay.io/enthought/edge-example-minimal:1.1.0"
+            image: "quay.io/enthought/edge-example-minimal:1.2.0"
           },
           {
             directory: "Panel",
             environment: "edge-panel-example",
-            image: "quay.io/enthought/edge-panel-example:1.2.0"
+            image: "quay.io/enthought/edge-panel-example:1.3.0"
           },
           {
             directory: "Plotly Dash",
             environment: "edge-plotly-dash-example",
-            image: "quay.io/enthought/edge-plotly-dash-example:1.2.0"
+            image: "quay.io/enthought/edge-plotly-dash-example:1.3.0"
           },
           {
             directory: "React",
             environment: "edge-react-example",
-            image: "quay.io/enthought/edge-native-app-flask-demo:1.2.0"
+            image: "quay.io/enthought/edge-native-app-flask-demo:1.3.0"
           },
           {
             directory: "Streamlit",
             environment: "edge-streamlit-example",
-            image: "quay.io/enthought/edge-streamlit-example:1.2.0"
+            image: "quay.io/enthought/edge-streamlit-example:1.3.0"
           }
         ]
       fail-fast: false

--- a/Minimal/Dockerfile
+++ b/Minimal/Dockerfile
@@ -1,7 +1,7 @@
 # This is the Dockerfile for the Enthought Edge "minimal" example.
 # 
-# We use "edm-centos-7" as the base image.  This is a Centos-7 based image
-# which includes EDM.
+# We use "edm-rockylinux-8" as the base image.  This is a Rockylinux-8 based
+# image which includes EDM.
 #
 # EDM dependencies for the app are brought in via a .zbundle file.  This avoids
 # the need to pass your EDM token and/or a custom edm.yaml into the Dockerfile.
@@ -18,7 +18,7 @@
 
 # First stage
 
-ARG BASE_IMAGE=quay.io/enthought/edm-centos-7:latest
+ARG BASE_IMAGE=quay.io/enthought/edm-rockylinux-8:latest
 
 FROM $BASE_IMAGE as stage_one
 

--- a/Minimal/ci/__main__.py
+++ b/Minimal/ci/__main__.py
@@ -13,15 +13,13 @@
 import click
 import os.path as op
 import subprocess
-import sys
-import os
 import json
 
 SRC_ROOT = op.abspath(op.join(op.dirname(__file__), ".."))
 
 # Docker image will be tagged "IMAGE:VERSION"
 IMAGE = "quay.io/enthought/edge-example-minimal"
-VERSION = "1.1.0"
+VERSION = "1.2.0"
 
 # These will go into the built Docker image.  You may wish to modify this
 # minimal example to pin the dependencies, or use a bundle file to define them.

--- a/Panel/Dockerfile
+++ b/Panel/Dockerfile
@@ -1,7 +1,7 @@
 # This is the Dockerfile for the Enthought Edge "Panel" example.
 # 
-# We use "edm-centos-7" as the base image.  This is a Centos-7 based image
-# which includes EDM.
+# We use "edm-rockylinux-8" as the base image.  This is a Rockylinux-8 based
+# image which includes EDM.
 #
 # EDM dependencies for the app are brought in via a .zbundle file.  This avoids
 # the need to pass your EDM token and/or a custom edm.yaml into the Dockerfile.
@@ -18,7 +18,7 @@
 
 # First stage
 
-ARG BASE_IMAGE=quay.io/enthought/edm-centos-7:latest
+ARG BASE_IMAGE=quay.io/enthought/edm-rockylinux-8:latest
 
 FROM $BASE_IMAGE as stage_one
 

--- a/Panel/ci/__main__.py
+++ b/Panel/ci/__main__.py
@@ -21,7 +21,7 @@ SRC_ROOT = op.abspath(op.join(op.dirname(__file__), ".."))
 
 # Docker image will be tagged "IMAGE:VERSION"
 IMAGE = "quay.io/enthought/edge-panel-example"
-VERSION = "1.2.0"
+VERSION = "1.3.0"
 
 # These will go into the built Docker image.  You may wish to modify this
 # minimal example to pin the dependencies, or use a bundle file to define them.

--- a/Plotly Dash/Dockerfile
+++ b/Plotly Dash/Dockerfile
@@ -1,7 +1,7 @@
 # This is the Dockerfile for the Enthought Edge "Plotly Dash" example.
 # 
-# We use "edm-centos-7" as the base image.  This is a Centos-7 based image
-# which includes EDM.
+# We use "edm-rockylinux-8" as the base image.  This is a Rockylinux-8 based
+# image which includes EDM.
 #
 # EDM dependencies for the app are brought in via a .zbundle file.  This avoids
 # the need to pass your EDM token and/or a custom edm.yaml into the Dockerfile.
@@ -18,7 +18,7 @@
 
 # First stage
 
-ARG BASE_IMAGE=quay.io/enthought/edm-centos-7:latest
+ARG BASE_IMAGE=quay.io/enthought/edm-rockylinux-8:latest
 
 FROM $BASE_IMAGE as stage_one
 

--- a/Plotly Dash/ci/__main__.py
+++ b/Plotly Dash/ci/__main__.py
@@ -21,7 +21,7 @@ SRC_ROOT = op.abspath(op.join(op.dirname(__file__), ".."))
 
 # Docker image will be tagged "IMAGE:VERSION"
 IMAGE = "quay.io/enthought/edge-plotly-dash-example"
-VERSION = "1.2.0"
+VERSION = "1.3.0"
 
 # These will go into the built Docker image.  You may wish to modify this
 # minimal example to pin the dependencies, or use a bundle file to define them.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This GitHub repo holds working examples of apps supported by Enthought Edge.
 
-Each example is a standalone container that inherits from `edm-centos-7`.
+Each example is a standalone container that inherits from `edm-rockylinux-8`.
 
 The examples are self-contained, with their own README.md and "ci" module that
 contains build commands.  For new users, the recommended workflow for

--- a/React/Dockerfile
+++ b/React/Dockerfile
@@ -1,7 +1,7 @@
 # This is the Dockerfile for the Enthought Edge "React" example.
 # 
-# We use "edm-centos-7" as the base image.  This is a Centos-7 based image
-# which includes EDM.
+# We use "edm-rockylinux-8" as the base image.  This is a Rockylinux-8 based
+# image which includes EDM.
 #
 # EDM dependencies for the app are brought in via a .zbundle file.  This avoids
 # the need to pass your EDM token and/or a custom edm.yaml into the Dockerfile.
@@ -18,7 +18,7 @@
 
 # First stage
 
-ARG BASE_IMAGE=quay.io/enthought/edm-centos-7:latest
+ARG BASE_IMAGE=quay.io/enthought/edm-rockylinux-8:latest
 
 FROM $BASE_IMAGE as stage_one
 

--- a/React/ci/__main__.py
+++ b/React/ci/__main__.py
@@ -21,7 +21,7 @@ SRC_ROOT = op.abspath(op.join(op.dirname(__file__), ".."))
 
 # Docker image will be tagged "IMAGE:VERSION"
 IMAGE = "quay.io/enthought/edge-native-app-flask-demo"
-VERSION = "1.2.0"
+VERSION = "1.3.0"
 
 # These will go into the built Docker image.  You may wish to modify this
 # minimal example to pin the dependencies, or use a bundle file to define them.

--- a/Streamlit/Dockerfile
+++ b/Streamlit/Dockerfile
@@ -1,7 +1,7 @@
 # This is the Dockerfile for the Enthought Edge "Streamlit" example.
 # 
-# We use "edm-centos-7" as the base image.  This is a Centos-7 based image
-# which includes EDM.
+# We use "edm-rockylinux-8" as the base image.  This is a Rockylinux-8 based
+# image which includes EDM.
 #
 # EDM dependencies for the app are brought in via a .zbundle file.  This avoids
 # the need to pass your EDM token and/or a custom edm.yaml into the Dockerfile.
@@ -18,7 +18,7 @@
 
 # First stage
 
-ARG BASE_IMAGE=quay.io/enthought/edm-centos-7:latest
+ARG BASE_IMAGE=quay.io/enthought/edm-rockylinux-8:latest
 
 FROM $BASE_IMAGE as stage_one
 

--- a/Streamlit/ci/__main__.py
+++ b/Streamlit/ci/__main__.py
@@ -21,7 +21,7 @@ SRC_ROOT = op.abspath(op.join(op.dirname(__file__), ".."))
 
 # Docker image will be tagged "IMAGE:VERSION"
 IMAGE = "quay.io/enthought/edge-streamlit-example"
-VERSION = "1.2.0"
+VERSION = "1.3.0"
 
 # These will go into the built Docker image.  You may wish to modify this
 # minimal example to pin the dependencies, or use a bundle file to define them.


### PR DESCRIPTION
Closes #80 

Centos-7 is reaching end of life, so switch over to Rockylinux-8, which is good into 2029.
