### PR TITLE
88 - Change edge dependency

### DIFF
--- a/Minimal/app_config.yaml
+++ b/Minimal/app_config.yaml
@@ -8,6 +8,7 @@ organisation: enthought
 env_deps:
   edm:
   - click
+  - enthought_edge
   - filetype
   - oauthlib
   - pip
@@ -17,7 +18,6 @@ env_deps:
   - setuptools
   pip:
   - questionary
-  - src_edge/src
 app_deps:
 - flask
 - setuptools

--- a/Panel/app_config.yaml
+++ b/Panel/app_config.yaml
@@ -8,6 +8,7 @@ organisation: enthought
 env_deps:
   edm:
   - click
+  - enthought_edge
   - filetype
   - oauthlib
   - pip
@@ -17,7 +18,6 @@ env_deps:
   - setuptools
   pip:
   - questionary
-  - src_edge/src
 app_deps:
 - enthought_edge>=2.16.0
 - appdirs

--- a/Plotly Dash/app_config.yaml
+++ b/Plotly Dash/app_config.yaml
@@ -8,6 +8,7 @@ organisation: enthought
 env_deps:
   edm:
   - click
+  - enthought_edge
   - filetype
   - oauthlib
   - pip
@@ -17,7 +18,6 @@ env_deps:
   - setuptools
   pip:
   - questionary
-  - src_edge/src
 app_deps:
 - enthought_edge>=2.16.0
 - appdirs

--- a/React/app_config.yaml
+++ b/React/app_config.yaml
@@ -8,6 +8,7 @@ organisation: enthought
 env_deps:
   edm:
   - click
+  - enthought_edge
   - filetype
   - gunicorn
   - oauthlib
@@ -18,7 +19,6 @@ env_deps:
   - setuptools
   pip:
   - questionary
-  - src_edge/src
 app_deps:
 - enthought_edge>=2.16.0
 - appdirs

--- a/Streamlit/app_config.yaml
+++ b/Streamlit/app_config.yaml
@@ -8,6 +8,7 @@ organisation: enthought
 env_deps:
   edm:
   - click
+  - enthought_edge
   - filetype
   - oauthlib
   - pip
@@ -17,7 +18,6 @@ env_deps:
   - setuptools
   pip:
   - questionary
-  - src_edge/src
 app_deps:
 - enthought_edge>=2.16.0
 - appdirs


### PR DESCRIPTION
Closes #88 

Don't include edge from source in the bootstrap, but instead from EDM.  Note that you need to have edge-dev repository until we publish again.