### PR TITLE
100 - Fix streamlit docker warnings

### DIFF
--- a/Streamlit/Dockerfile
+++ b/Streamlit/Dockerfile
@@ -20,7 +20,7 @@
 
 ARG BASE_IMAGE=quay.io/enthought/edm-rockylinux-8:latest
 
-FROM $BASE_IMAGE as stage_one
+FROM $BASE_IMAGE AS stage_one
 
 ARG EDGE_BUNDLE=app_environment.zbundle
 COPY $EDGE_BUNDLE /tmp/app_environment.zbundle
@@ -38,7 +38,7 @@ RUN edm run -- python -m pip install --no-cache-dir \
 
 # Second stage
 
-FROM $BASE_IMAGE as stage_two
+FROM $BASE_IMAGE AS stage_two
 
 LABEL source="https://github.com/enthought/edge-examples/blob/main/Streamlit/Dockerfile"
 


### PR DESCRIPTION
From support ticket [#157](https://edge-support.enthought.com/a/tickets/157?current_tab=details)

Below are warnings coming from the example streamlit docker file created with edge app init:

2 warnings found (use docker --debug to expand):

FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 23)
FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 41)

This PR addresses this issue by using `AS`